### PR TITLE
Fixed to dump response correctly on error API response.

### DIFF
--- a/bin/akamai-mpulse
+++ b/bin/akamai-mpulse
@@ -124,7 +124,7 @@ On success, returns a value object built from a JSON response.
             response = http_response.json()
         else:
             log.error("HTTP Error" + str(http_response.status_code))
-            log.error(http_response.read())
+            log.error(http_response.content)
     except Exception as e:
         logging.error(str(e))
 


### PR DESCRIPTION
This is an one-line fix to dump an error correctly when mPulse API returned an error response. It seems original code first expected (or used) the urllib API, but then switched to the requests API.

References:
- https://docs.python.org/3/library/urllib.request.html#module-urllib.request
- https://requests.readthedocs.io/en/latest/api/#requests.Response